### PR TITLE
Abstract Custom Settings from Plugin implementation

### DIFF
--- a/ExporterConfiguration/CustomSettings.cs
+++ b/ExporterConfiguration/CustomSettings.cs
@@ -1,0 +1,256 @@
+﻿using System.IO;
+using Newtonsoft.Json;
+
+namespace MusicBeePlugin
+{
+    internal static class CustomSettings
+    {
+        internal static class Persistence
+        {
+            private const string FolderName = "ObsExporterPlugin";
+            private const string TrackDetailFilename = "TrackDetails.json";
+
+            private static string _musicBeeAllocatedStoragePath = string.Empty;
+            public static string PluginStoragePath { get; private set; } = string.Empty;
+            public static string TrackDetailsFilePath { get; private set; } = string.Empty;
+
+            /// <summary>
+            /// Gets or sets the storage path allocated by MusicBee
+            /// </summary>
+            /// <value>
+            /// The allocated storage absolute path.
+            /// </value>
+            public static string MusicBeeAllocatedStoragePath
+            {
+                get => _musicBeeAllocatedStoragePath;
+                set
+                {
+                    _musicBeeAllocatedStoragePath = value;
+                    
+                    // atomically update plugin storage path
+                    PluginStoragePath = Path.Combine(MusicBeeAllocatedStoragePath , FolderName);
+
+                    // atomically update track detail configuration path
+                    TrackDetailsFilePath = Path.Combine(PluginStoragePath , TrackDetailFilename);
+                }
+            }
+
+            /// <summary>
+            /// Loads the persisted plugin settings.
+            /// </summary>
+            public static void LoadPersistedPluginSettings()
+            {
+                if (File.Exists(TrackDetailsFilePath))
+                {
+                    string trackDetailsString;
+                    using (var sr = new StreamReader(TrackDetailsFilePath))
+                    {
+                        trackDetailsString = sr.ReadToEnd();
+                    }
+
+                    var trackDetailsObj = JsonConvert.DeserializeObject<TrackDetails>(trackDetailsString);
+                    TrackDetails.Instance.Initialize(trackDetailsObj);
+                }
+            }
+
+            /// <summary>Creates the data persistence folder if it does not exists and save the custom settings into a Json File</summary>
+            /// 
+            public static void SavePluginSettings()
+            {
+                var customSettingJson = JsonConvert.SerializeObject(TrackDetails.Instance);
+
+                using (var sw = new StreamWriter(TrackDetailsFilePath, false))
+                {
+                    sw.Write(customSettingJson);
+                }
+            }
+
+            /// <summary>
+            /// Purges the plugin folder.
+            /// </summary>
+            public static void PurgePluginFolder()
+            {
+
+                if (Directory.Exists(PluginStoragePath)) Directory.Delete(PluginStoragePath, true);
+            }
+        }
+
+        [JsonObject(MemberSerialization.OptIn)]
+        internal sealed class TrackDetails
+        {
+            private const string DefaultArtworkOutputFilename = "cover.png";
+            private const string DefaultArtistNameOutputFilename = "artist.txt";
+            private const string DefaultAlbumNameOutputFilename = "album.txt";
+            private const string DefaultTrackTitleOutputFilename = "title.txt";
+            private static TrackDetails _instance;
+            private string _albumNameOutputPath;
+            private string _artistNameOutputPath;
+            private string _artworkOutputPath;
+            private string _trackTitleOutputPath;
+
+            public static TrackDetails Instance => _instance ?? (_instance = new TrackDetails());
+
+
+            /// <summary>
+            ///     Default cover art image in Base64 string
+            /// </summary>
+            [JsonProperty]
+            public string DefaultCoverArt { get; set; } =
+                @"/9j/4AAQSkZJRgABAQEBLAEsAAD//gATQ3JlYXRlZCB3aXRoIEdJTVD/4gKwSUNDX1BST0ZJTEUAAQEAAAKgbGNtcwQwAABtbnRyUkdCIFhZWiAH5AAJAAkACgAPAANhY3NwTVNGVAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA9tYAAQAAAADTLWxjbXMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA1kZXNjAAABIAAAAEBjcHJ0AAABYAAAADZ3dHB0AAABmAAAABRjaGFkAAABrAAAACxyWFlaAAAB2AAAABRiWFlaAAAB7AAAABRnWFlaAAACAAAAABRyVFJDAAACFAAAACBnVFJDAAACFAAAACBiVFJDAAACFAAAACBjaHJtAAACNAAAACRkbW5kAAACWAAAACRkbWRkAAACfAAAACRtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACQAAAAcAEcASQBNAFAAIABiAHUAaQBsAHQALQBpAG4AIABzAFIARwBCbWx1YwAAAAAAAAABAAAADGVuVVMAAAAaAAAAHABQAHUAYgBsAGkAYwAgAEQAbwBtAGEAaQBuAABYWVogAAAAAAAA9tYAAQAAAADTLXNmMzIAAAAAAAEMQgAABd7///MlAAAHkwAA/ZD///uh///9ogAAA9wAAMBuWFlaIAAAAAAAAG+gAAA49QAAA5BYWVogAAAAAAAAJJ8AAA+EAAC2xFhZWiAAAAAAAABilwAAt4cAABjZcGFyYQAAAAAAAwAAAAJmZgAA8qcAAA1ZAAAT0AAACltjaHJtAAAAAAADAAAAAKPXAABUfAAATM0AAJmaAAAmZwAAD1xtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAEcASQBNAFBtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEL/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/2wBDAQMEBAUEBQkFBQkUDQsNFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBT/wgARCAEsASwDAREAAhEBAxEB/8QAHQABAQACAwEBAQAAAAAAAAAAAAgGBwIEBQMBCf/EABQBAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhADEAAAAZUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPqbqMPMAAAAAAAAAAAAAAAAB2yqSSytzW5TZCxjwAAAAAAAAAAAAAByOIKsNPlIHXJ8PGMHAAAAAAAAAAAAABsU2mdgzYmcqcn030eIYQToAAAAAAAAAAAAAAXAauNHlhmmDmadOJ4oAAAAAAAAAAABsM14Z6UseCaBKXIzLfIlMjMVAAAAAAAAAAAAMoMhN9E4mxTgUGT6bEMhNOmhAAAAAAAAAAAAADtm5DWZW5HpYJLxZxBJ1T4gAAAAAAAAAAAA/Tbp4plJ7x2jDzch9SRDzAAAAAAAAAAAAAD6FOHklEkSlTEgm/wAl8AAAAAAAAAAAAAAFkkjFpGgyjSRz6mvwAAAAAAAAAAAAAd4qglcskjIuQwgxQnY4AAAAAAAAAAAAAG1CgjBDU5UQIwPWO4YOAAAAAAAAAAAAAekeeb+O6b6JIMPKtJMPFAAAAAAAAAAAAPRMoMMN+m0Tziejexqw36RCAAAAAAAAAAAADmcDvlyEZFyn89CnTBTe54pIp8QAAAAAAAAAAAAUwa7NVm+D1zuGBmqiiSbAAAAAAAAAAAAAAD0i3yEjiXiQ2VEScAAAAAAAAAAAAAAADf57pPhaRDB8wAAAAAAAAAAAAAAADkUuZQTYYiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD//EACMQAAICAwACAgMBAQAAAAAAAAUGAwQBAgcVQAAUExZQgBD/2gAIAQEAAQUC/wBNxRbzyDeRGr0DEjlFr+DU/Di06pVC2p/OYBqodfLdQNl761qSKrzBQhFmfdzjOuf+ciZ8SxdAWMrJ5KhiZuc5kV+XwNHQyjN81TiOy77iDco02XrqriGZU5bW+jY5stG65QSQRTxmpB0dK544ZVSbLz0e5bCuUjAOX7o0RCv7qEbhclrshKxgmFN2wN5pp13tI5S0+JKdZVvFlKBwgM+XzV4p7UqIWgX/AIqJ1xts6qaeqRMvOBhcWosEiuc6ct/sojOM4zz+CQUgfkzpMaZyTB7S2C2YyzwnbqBDljFoaEt67usHBPR8BE5W53ebthZpdW7nVlXxBXkLT9mseKKoMy69O3PV/bqWpaNkUpmegwiCVhbMuwiJ4Uw0Olkt1MrcBgU4dZKsjhYEkAtS7MNtTTSWJPaxjO2Q3LjZeFiQyq1py5p8IY66rfSu8iafrWOmLGV46uPwdiDXnVaT6pIhMVve3+PbOnOBIkWGK9SMmiC7WJ3gTcuyKpxTJQPqhdqWlo00PQdgTPeZR9aflsMtiXSnVGcwXN+ilizH0hY/YgScy7qpl1adWwt7lHSCS2U5eMKA7tKcdZVc+a5dXm2q2TYuDpKqq8q8NcZeqXNCW++ZN/bTUC22beASV3DvzerGNUnS6qWro4L1ATzgTbB0y1b6ZQI0k17Y26F2CP24RtuzHnGdc3Om5iVVTlcpXUKxAfudCWMrR0KctgLtfsY3xBklkwU9kePsFbjQn3lPeKLeeRI55vIVk6uDH3H9PqHxSJViuNnYjV6ljlo2xca+j2BBZa9rXTaTb5QuyjbhCvX6UlByU60bPT+dSvnIGjGu72ClUWWi6LjeMNdCCLFKaXeeX2uNXaH2uiq/60e+coafEFuvq307vIWjEUnS1f8AXzlW1JSsuj6KY1f3RpCYVfMVK/R0qSPaGTXbOmwaxq8IMM0o260N4RjSP4HJmvxRLqSNJraHh7pSwPgi50kSb5lk/g67Z02V+vZqVrvYRVSJhaiLNY/yd//EABQRAQAAAAAAAAAAAAAAAAAAAKD/2gAIAQMBAT8BNJ//xAAUEQEAAAAAAAAAAAAAAAAAAACg/9oACAECAQE/ATSf/8QAPBAAAgEDAQYBCQYFBAMAAAAAAQIDAAQREgUTISJBUTEUIyQyQEJhcYEGEBVSkcEzUFNi4XKAobFE0dL/2gAIAQEABj8C/wBzaxxo0jtwCqMk0JJd3aZ9yQ8a1XMOuH+rHxX+QxeUAmDUNYXxxVvfbFgWPyZdeE4l06/M/dNt+7HOQSpPuqKxs92t4ycRxRJljTR/aO2jRnBGD4lfiOlXdrbzrcwRvhJEOQR7dgjB++TYty2esWrt2p0RcWk3nIf3H0r8P3m75WgY/lrC+kbRx/qlP/yKaNn8lsz/AOPEfH5nrUm2d1i2QjlIOoj83y9ttjfwRzRPygyDIRuhpNsWyebkwkoXv0NJtHbk2hGGoQ50gfM0w2dII5BwDwyav1qPXweNtcUg8HFLPBg3Krrj+D9RRt7oEWkraZAfcPel2hY3IhlkHF05levLNrXolWLmw3In1o7L2Ry2nqvJjGodh7c1heYeeEaJAeo6GrawDFbVIg2nuajubWUoynivRh2pb6D+Kib6M9iPEV+Hzt6Pcerno1DaUC+jXR58e6/+a9FvJoB2Vq9Lu5Zx2duHtTbXkhCW4wdGefT+bH3FIMRQp68zeC0se0JIpZurXDcf06U20Ps+RrClhHGcq9RXPER50Sr/AG1BtSwXfTQrnC+8hrBHHtTNdjdKRJJhvy1rQ6SGyCOlIL25aSNPVjHBR9PaorFJkty/vvUcQczW0q5SQjr1FS7GvMO8a4Ab3kqa0Od160Td1oWFrFo2hnGvHDHevxHaNw0NrJza/F5Kt9g2DjescEIdWD8T3ry+BcWt0cnHuv1ptkXDc8XGLPVe1ONo7PjW79cMsWrVTWGz4jbWZ4M59Z//AEPbI54W0SxnUpqfalzfBtIITeHJJ7Y6Co7hcpLA+HT/ALFRbRs+e4iXex46jqtWcUn8N5VU/rVtDYeaikOh3HQVZLCGYrKHZuwFbRs7+5jg3XDU54hsZGKE9rK0Uqeq600krtJI3Es5yT7XgcTQmMQtIz4b/gT9K3lxEJIP6sXECvJJmxa3Jxx6NS7Xt18xccJcdG7/AFptkXDebk4xZ79q8ogXFpdHWmPdbqKSx24YknA0sJvVf4067HhinuXHAW44fVqnu521SytqPthfSdAONWOFSfaC/mRnU4AbHm/815PsaLdoTiNUTU7UYftFHE0kgwUHHh8altuO7zrhfuvSpbC85plXdyfs1PC2Y7m2k4H/AKNRwT6pNouMqiD+G46k+3xtaQJCgRJdMYx86WzSRt3I483ngTS3MyB7txhmxzO3arKZpTHAsw020fBe3HvRmiXN5bDWncjqKW54mE8sqDqK8qW1W2VV0DqzD4+2xLdSNFbk87ouSBUU+wZcyquQxbO9+dPb3EbRSocFWFPB1EMkX6VHKBzRsGwfhVtJazKsnroT0bqDS3+1riNlh5hGnhnuTV9Fst0EDYVZSM4x1FFmOWPEn2ze6vJrIHDS4yT8qFtdNbvL4EzNqam2rsTmiUamiU5GnuKG7O8tSeeBvD6UJ4HCXSj1x6yHsa2jsq9XDI+pT0ZSPEVdwYxu5WXH1o+Q3LRKfFPFTW7u7tjF/TTlU+2byK2mlT8yISKweBq02fs5PJ7nRplcD1flQv8AbMxgt2592DzN8z0obB2aysI0PBOKfLPWnCL6JNzxH9qS5tJTGw8R0YdqE88L+Xjh5Og8T8+1XN6Y1hMz6tC9Pao7W1iM08nqoKtxd6W3y5DR8QD1FLHGjSSNwCqMk1K+27fdQW6CQxSe9nvQs4LZzbqdG8jUBR9KG2dlhd6F1Hd+EgrZ0U4ym8ziraygO6tJV52HvfCreeNTuoMs71Pv7qOK4hciLJ5i46e16VBY9h90N1A2maJtSmg8WBMV1x/2SDp+1RXAUrLbvh0P/Iq8uLHnae3yNPifh90mw7k+bky8Ge/Vf3/Wlurbkid97E3Zqjj2vuI5gOaKfwz8DT2ewYUkmb3ohhF+Z608kjanY6ifj7Xc2ctvH5aw1RzEcSvVafdLizuPORfDuv3fh874tbo8ufdf/NLti3XzNwdM2Oj9/rT7GuW5H5oc/wDIppYl9EuudfgeoqKeFtEsbBlYdDVvCYmfaLAMQOAibrx9ugu4DplhbUKWWDG/K7yLPuyD3f2pkcFXU4IPQ0GU4I4gitNyAztGUf8A1DrSyRsUmhfIPxFJ5VL6c65SJBl1cft/ITs24fFtc+pn3X/zT7YsIy8cnGaNBnB70sNrbSSuTjgtOLqQb7BbHdz0FM58WOf5EGU4I4gilttrQmYKMCZPH6im/D7J5JT3XQK3l7NlfdiXgi/7T//EACkQAQABAwMCBgIDAQAAAAAAAAERACExQVFhcYFAkaGxwfAQ4VDR8YD/2gAIAQEAAT8h/wCm1xFLkbAVJdmSV3hiiyY2PXtsa/wLRuakKd47UNu1SRk5DMs67/gVfoJrrT2I1HVZlpdABzlYl9tSkIhdAJ3MPJ46cLYT8giiO+1VurimgT6r0SjZSSZdTmKdEPeEde4scd601JKged7eKSyJQCbIIwt41gbXwCWcZoH1sljDv48qPEBsycLe3vQe7YCHhNOvDxL/AE361fFJagXetysHjQOOz3o8tEULMpveipvkgMayvakc0XF7R45BRuY/U+Y0CyCMT57RRppoOUSjmKLIdwQX/Uf1UhBfg/f9zVq/GLfpX6jQqMNWHlUWBmRDLp4q42RSS2MGM/h7UoOvY1eKiReZpvRTGUoN3g2a5bU7rNtzNPDgZLnR0z50rYBhWZqE0JZhTE9auGwGSmSoaRDTOJhl5fFSQYdMDY1eKtE8+UZo596UVRfZrR8UcqbP18dzHaj1AzJB6+anQWfnRodXyqYvcAfTRUXJABbQd8+dX/yn7ns9kqNEgoA6sa212q+ZoYA0g+m3jFHgh0SsbtK+WAtN/lBZNZmzD0e5u5i+3IVuxmxZFYgMm5lg61vmzfJVaHig3BkZXgpLIMuE0pCqS1W6ufFmAUYAy1cNbNC31Hei7haV67aoKCV62m98eVBftNLHboHqc0Ny9n2NXy86VsYaUZeDc/VALGZxgd8Vb6ATodri9Tsjf48oO3jAVcCwHaab5qxkbcqlM79LP+Wp/PrgXppm+k1PGPQVHVufFR5Qs5nQ9GmFsJtMMhwkPejJA3JqBg9x8fEUXm+0ndzWJFC9KKUfQIbxeDsVL1Plhe4h1o5xCI+tvUMt8P8AsKBZ6G6WXjy9fGhRTzGQb1PiKB+pozTm2RjDHlzQJcIxdGbUS5ObimoiwEJIo7qSnupOMBwLFLuOXsEOjfdmn3NUavjJivc8iH5pA45+PO1TfXX1q6ZeOKSHKmXG+xvVkNyAiYdS9Wxsufuj7d8ZhCLCimRSlw7BoZrj54DPfxn+xZoCnAIWR0qBZWSAe5rbsY3mUwfO+lRO8bBZkypRxLpgc9lPmPqglHarUGn3BpPqKQCJpJLxT4iiCT54qAenhE1dy3nT8glyNgM00bHg0LHFmSpnhxD3NlW36wP2yKl6Mi1QU9qaQq5K5bRXCsrFkj1qCgdkRhIXh8WQWcDK/iHlXMPirthpznL1XDT9C56Bjr5omMiuJE/L8FHdkf7VE/YB9JmPvNJYCbUEu7VEUps0b6jj2pUj69Uyvn4s4K6Z2xI43tmeKXIWoW/qPon4loBCVtH4eVaNIBaK3YPM5oSt+Xr9XzpWURULfcf8ps+eYDJQtfk6sZ7eOgDq/wAdEtWVcdXJdeqppqjoQsjSQHSEI089G942bDXCWEkqI00jLS7Sm7k/gbjDlK36XqG9Q+dRrDENG092rCT9kHl0pFOWCDiXL1lFjjd/gkgOkIR3rKU86P8ACmIStFLzSOIvtyfL/wAn/wD/2gAMAwEAAgADAAAAEJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJIIJBJJJJJJJJJJJJJJBJAIBJJJJJJJJJJJJJJBABIJJJJJJJJJJJJJJJAIBJJJJJJJJJJJJJIIAJBAJJJJJJJJJJJJIIJJIJJJJJJJJJJJJJJJJJBAJJJJJJJJJJJJJJBBIAJJJJJJJJJJJJJJJBBBJJJJJJJJJJJJJJJIJJJJJJJJJJJJJJJJJBAABJJJJJJJJJJJJJJJIBAJJJJJJJJJJJJJIBAIAJJJJJJJJJJJJJIBAIBJJJJJJJJJJJJIJABJIJJJJJJJJJJJJJIJBIIJJJJJJJJJJJJJJJBIAJJJJJJJJJJJJJJJJIAJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJP/8QAFBEBAAAAAAAAAAAAAAAAAAAAoP/aAAgBAwEBPxA0n//EABQRAQAAAAAAAAAAAAAAAAAAAKD/2gAIAQIBAT8QNJ//xAAmEAEBAAICAgICAQUBAAAAAAABEQAhMUFRYUBxgZEQUIChweHR/9oACAEBAAE/EP7myJtRu4AVfQYXbR+J1uifFocx1lM6EkFFkb1WwHG/6CJvro5bo72/5zmubHIY77ANwwfwfDNg5pdpWX8mBEWEXoO77odaO7bqRAx1rE8WwqJQUVapO0CjX7j5ysG5cJ3w/wAjyKhR9buYujwh1iKIfAXo/YGGoARVmbt6ROnvswI6KG0+xbTTXCxMy4BKJNfZpDBgP1YSg2Rp4iug38wLbaoRY1BKjFEkcoqIWJkB4R/949oB+doRVJrDpxEg8SybUOzffOAeKrcQ0zVIHX75zL2xVCjg2fDvrANWIRnYtkdDqPvAi9QQEASeQ2zGH8eFtZURopd3wCUEY8NTd32wvVt+cp1gR8T99v8AAzUWcliBa5A1e+OM1vucxFqIIWUusb7QbthD1xHhLyMdelpulx6Afs843hxGqlX0B0/IMh3YfxzUP1h8pV15dKda18o0Ug7laBjaoYqhP4KPSpQsBOrkfeTakVc0JqHgDq7S4FrEkQo160NhXfGId2DAsKfJ01dJ3lLqE0g8hVs+oOTEAMIQBiJ5xbu2dKkHjtve86nOxBQQImuA+jOobaIIaNHY7dzXyi82tWBQN79UWOyYTmRowANKIT0DaLjwQk0ey8za54HvHmtMYtmtux+67MDXvGsK1L1Aezxm91Kl52k+NDxhcBhUNVdik4Kl4DNW9FHO/Yj/AMYB4+rttbXds+h05RKUygEuq2BdHZkgDUetB4kNNUdnzHMU+NX+R4TsUw2IATdThQBdcLXOIDdpERC86TfCD1iQbIBeV9XYCGvyM8LrLSnannzfFdYb+1NGiuCoV/3cIGDVgtp6nO7jCqABQAbFkKineap7OJFJTsXkz2uvsUSr2vywPmDqOgDtw6MlNkHSIR0Q04DeKfykBF6idO0mb4+IDIf4n2B3jHISF8V6ARdEO8FFFMOyf3v/AIYenOxVtnk83ChjbaDWFQ6ECTpc1/rIqboYNQVuzvHYaiILAEDQPoHzDoEdKRRcBQUPTiItMSiAErcCPqW41MlBttsapNQCr5GqQSC3SEzEQ1zuBcfkFAUDwRfOGUk41ANvYwThJ1l9g9ZxifCLxD3liWQdJqBGiFUQjfnEpdncyYyKBtAKIqVVV02Zrx0AYgjSi9msAxqScggoy86DAbAsdfBvaJBCBhM4YmAfzBB5PeI46zOXEFCnnpc1CnjCT2Qugarv5odXW2va+40cy2PGHURLaDTsxNAHExVYwnUoptIwaesV6yABXCK6HOnsNgLELWJQPfJh+RClqRsQI/eS7Tzh1G3QTfcw/blTKDUqeDQ44TkunQjV/fzDxaQ0D0gvJTB6eMg9KiU2zpPiADwXaRj/AD3gt2VXChcqhmtob9mdG+/OHgcFhzN+C+adY1N/QglHSUjJHScOGXGMICgNBJJqYuETJZKkx9kdZzYWIRvfueEhCF38x+cqOhudg1w+55xD6w4rwmb4aYBQultViafOLYDXDm9NuWWKqwrRaTCAs6naU6W4u5RCJftdPqPeBTpJthwSMe8POTUkilmxve5wnWObJsvpXl8sK1h8pR2WEYKqoAAqqGDulaBRUFBXh4WODnWvdwEq9BkmOdUStQAXbeEw8liONNAp9HTrzfoRskNoHcOTlvGCArGAGmouxor6lwxusoFh1Apht9TZ2nMISS+1eG+N53L4oQSQm2Q0vHy9Ql1e5oNv8LdJuwThiVFE7FMeQ1CSUVuC6HkOnC/JBEhxdRHpB6xJ3m36HG4iU55P4B+jWQi73rQeTyMNe0SFHrOyy79MEA5kJXAtWTcMF14ofpaKO4B4i45WAqtaGtpdefl6RBFvCpoyIhaacszqcWdX3E4+k/xrqoI4r9RPuebhvYZ0j25oIF0ezF9JmIMU/vZP9cXE3i9t+DbB4UCYSrNUBJ+zjvFkZnBZREqKA2SpfnO56y1OV7CvS4bMoBYDSypBeb0ZUuX5CB0iI/WGJ+kCaImxHdxTX90hteT0HCnJCx7mPFIlRKbyMHN0FBrUFARlv9BLpwXIgegJz+QyxlbDoiFaODTTlwzji+QOogBFXgTzgdSKAYJ4GGnrJR6JQorPy/0I3P0wTQJsR3cL1mQMumIwijvxiXmTaK1lZ5g7fzjBWkMnjvfYu3fX9p//2Q==";
+
+            /// <summary>
+            ///     Default string value to use if the artist name is missing from MusicBee's tag details
+            /// </summary>
+            [JsonProperty]
+            public string DefaultArtistName { get; set; } = "Ask in chat - Artist Name";
+
+            /// <summary>
+            ///     Default string value to use if the Track Title is missing from MusicBee's tag details
+            /// </summary>
+            [JsonProperty]
+            public string DefaultTrackTitle { get; set; } = "Ask in chat - Music Title";
+
+            /// <summary>
+            ///     Default string value to use if the album name is missing from MusicBee's tag details
+            /// </summary>
+            [JsonProperty]
+            public string DefaultAlbumName { get; set; } = "Ask in chat - Album Name";
+
+            /// <summary>
+            ///     Location of the text file where the artist name is captured.
+            /// If undefined, the album name will be stored in OBS Exporter's default output directory
+            /// </summary>
+            [JsonProperty]
+            public string ArtistNameOutputPath
+            {
+                get
+                {
+                    if (string.IsNullOrWhiteSpace(_artistNameOutputPath)) _artistNameOutputPath = Path.Combine(Persistence.PluginStoragePath, DefaultArtistNameOutputFilename);
+                    return _artistNameOutputPath;
+                }
+                set => _artistNameOutputPath = value;
+            }
+
+            /// <summary>
+            ///     Location of the text file where the track title is captured.
+            /// If undefined, the album name will be stored in OBS Exporter's default output directory
+            /// </summary>
+            [JsonProperty]
+            public string TrackTitleOutputPath
+            {
+                get
+                {
+                    if (string.IsNullOrWhiteSpace(_trackTitleOutputPath))
+                        _trackTitleOutputPath = Path.Combine(Persistence.PluginStoragePath,
+                            DefaultTrackTitleOutputFilename);
+                    return _trackTitleOutputPath;
+                }
+                set => _trackTitleOutputPath = value;
+            }
+
+            /// <summary>
+            ///     Location of the text file where the album name is captured.
+            /// If undefined, the album name will be stored in OBS Exporter's default output directory
+            /// </summary>
+            [JsonProperty]
+            public string AlbumNameOutputPath
+            {
+                get
+                {
+                    if (string.IsNullOrWhiteSpace(_albumNameOutputPath))
+                        _albumNameOutputPath = Path.Combine(Persistence.PluginStoragePath,
+                            DefaultAlbumNameOutputFilename);
+                    return _albumNameOutputPath;
+                }
+                set => _albumNameOutputPath = value;
+            }
+
+            /// <summary>
+            ///     Location of the image file where the Track's artwork is captured.
+            /// </summary>
+            [JsonProperty]
+            public string ArtworkOutputPath
+            {
+                get
+                {
+                    if (string.IsNullOrWhiteSpace(_artworkOutputPath))
+                        _artworkOutputPath = Path.Combine(Persistence.PluginStoragePath,
+                            DefaultArtworkOutputFilename);
+                    return _artworkOutputPath;
+                }
+                set => _artworkOutputPath = value;
+            }
+
+            /// <summary>
+            ///     Expected height (in pixels) of the artwork after it is resized by this plugin. Defaults to 300px
+            /// </summary>
+            [JsonProperty]
+            public int ArtworkOutputHeight { get; set; } = 300;
+
+            /// <summary>
+            ///     Expected width (in pixels) of the artwork after it is resized by this plugin. Defaults to 300px
+            /// </summary>
+            [JsonProperty]
+            public int ArtworkOutputWidth { get; set; } = 300;
+
+            public void Initialize(TrackDetails newCopy)
+            {
+                TrackTitleOutputPath = newCopy.TrackTitleOutputPath;
+                AlbumNameOutputPath = newCopy.AlbumNameOutputPath;
+                ArtistNameOutputPath = newCopy.ArtistNameOutputPath;
+                ArtworkOutputHeight = newCopy.ArtworkOutputHeight;
+                ArtworkOutputWidth = newCopy.ArtworkOutputWidth;
+                DefaultArtistName = newCopy.DefaultArtistName;
+                DefaultTrackTitle = newCopy.DefaultTrackTitle;
+                DefaultAlbumName = newCopy.DefaultAlbumName;
+                ArtworkOutputPath = newCopy.ArtworkOutputPath;
+                DefaultCoverArt = newCopy.DefaultCoverArt;
+            }
+        }
+
+        /// <summary>
+        ///     Contains Application constant values.
+        /// </summary>
+        internal static class Constants
+        {
+            /// <summary>
+            ///     Plug-in's name
+            /// </summary>
+            public const string Name = "MusicBee Now Playing OBS Exporter";
+
+            /// <summary>
+            ///     Plug-in's Description
+            /// </summary>
+            public const string Description =
+                "Export Now Playing music Metadata for OBS to consume and display during streaming.";
+
+            public const string Author = "Raven Ng";
+
+            /// <summary>
+            ///     Plug-in's major version number
+            /// </summary>
+            public const short VersionMajor = 1;
+
+            /// <summary>
+            ///     Plug-in's minor version number
+            /// </summary>
+            public const short VersionMinor = 0;
+
+            /// <summary>
+            ///     Plug-in's revision number
+            /// </summary>
+            public const short Revision = 1;
+
+            /// <summary>
+            ///     The name of a Plugin Storage device or panel header for a dockable panel
+            /// </summary>
+            public const string TargetApplication = "";
+
+            /// <summary>
+            ///     Height in pixels that MusicBee should reserve in a panel for config settings.
+            ///     When set, a handle to an empty panel will be passed to the Configure function
+            /// </summary>
+            public const int ConfigurationPanelHeight = 0;
+        }
+    }
+}

--- a/ExporterConfiguration/SettingsForm.Designer.cs
+++ b/ExporterConfiguration/SettingsForm.Designer.cs
@@ -1,0 +1,309 @@
+﻿namespace MusicBeePlugin
+{
+    partial class SettingsForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.lblDefaultArtistName = new System.Windows.Forms.Label();
+            this.txtDefaultArtist = new System.Windows.Forms.TextBox();
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.lblDefaultTrackTitle = new System.Windows.Forms.Label();
+            this.txtDefaultTrackTitle = new System.Windows.Forms.TextBox();
+            this.lblDefaultAlbumName = new System.Windows.Forms.Label();
+            this.txtDefaultAlbumName = new System.Windows.Forms.TextBox();
+            this.btnSave = new System.Windows.Forms.Button();
+            this.btnExit = new System.Windows.Forms.Button();
+            this.lblArtistOutputFile = new System.Windows.Forms.Label();
+            this.txtArtistOutputFile = new System.Windows.Forms.TextBox();
+            this.lblTrackTitleOutputFile = new System.Windows.Forms.Label();
+            this.txtTrackTitleOutputFile = new System.Windows.Forms.TextBox();
+            this.lblAlbumOutputFile = new System.Windows.Forms.Label();
+            this.txtAlbumOutputFile = new System.Windows.Forms.TextBox();
+            this.lblArtworkOutputFile = new System.Windows.Forms.Label();
+            this.txtArtworkOutputFile = new System.Windows.Forms.TextBox();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // lblDefaultArtistName
+            // 
+            this.lblDefaultArtistName.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblDefaultArtistName.AutoSize = true;
+            this.lblDefaultArtistName.Location = new System.Drawing.Point(4, 1);
+            this.lblDefaultArtistName.Name = "lblDefaultArtistName";
+            this.lblDefaultArtistName.Size = new System.Drawing.Size(148, 28);
+            this.lblDefaultArtistName.TabIndex = 1;
+            this.lblDefaultArtistName.Text = "Default Artist Name";
+            this.lblDefaultArtistName.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // txtDefaultArtist
+            // 
+            this.txtDefaultArtist.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtDefaultArtist.Location = new System.Drawing.Point(159, 4);
+            this.txtDefaultArtist.Name = "txtDefaultArtist";
+            this.txtDefaultArtist.Size = new System.Drawing.Size(658, 22);
+            this.txtDefaultArtist.TabIndex = 2;
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.CellBorderStyle = System.Windows.Forms.TableLayoutPanelCellBorderStyle.Single;
+            this.tableLayoutPanel1.ColumnCount = 2;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.Controls.Add(this.txtDefaultTrackTitle, 1, 1);
+            this.tableLayoutPanel1.Controls.Add(this.lblDefaultTrackTitle, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.txtDefaultArtist, 1, 0);
+            this.tableLayoutPanel1.Controls.Add(this.lblDefaultArtistName, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.lblDefaultAlbumName, 0, 2);
+            this.tableLayoutPanel1.Controls.Add(this.txtDefaultAlbumName, 1, 2);
+            this.tableLayoutPanel1.Controls.Add(this.lblArtistOutputFile, 0, 3);
+            this.tableLayoutPanel1.Controls.Add(this.txtArtistOutputFile, 1, 3);
+            this.tableLayoutPanel1.Controls.Add(this.lblTrackTitleOutputFile, 0, 4);
+            this.tableLayoutPanel1.Controls.Add(this.txtTrackTitleOutputFile, 1, 4);
+            this.tableLayoutPanel1.Controls.Add(this.txtAlbumOutputFile, 1, 5);
+            this.tableLayoutPanel1.Controls.Add(this.lblArtworkOutputFile, 0, 6);
+            this.tableLayoutPanel1.Controls.Add(this.lblAlbumOutputFile, 0, 5);
+            this.tableLayoutPanel1.Controls.Add(this.txtArtworkOutputFile, 1, 6);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Top;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 8;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(800, 369);
+            this.tableLayoutPanel1.TabIndex = 3;
+            // 
+            // lblDefaultTrackTitle
+            // 
+            this.lblDefaultTrackTitle.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblDefaultTrackTitle.AutoSize = true;
+            this.lblDefaultTrackTitle.Location = new System.Drawing.Point(4, 30);
+            this.lblDefaultTrackTitle.Name = "lblDefaultTrackTitle";
+            this.lblDefaultTrackTitle.Size = new System.Drawing.Size(148, 28);
+            this.lblDefaultTrackTitle.TabIndex = 3;
+            this.lblDefaultTrackTitle.Text = "Default Track Title";
+            this.lblDefaultTrackTitle.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // txtDefaultTrackTitle
+            // 
+            this.txtDefaultTrackTitle.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtDefaultTrackTitle.Location = new System.Drawing.Point(159, 33);
+            this.txtDefaultTrackTitle.Name = "txtDefaultTrackTitle";
+            this.txtDefaultTrackTitle.Size = new System.Drawing.Size(658, 22);
+            this.txtDefaultTrackTitle.TabIndex = 4;
+            // 
+            // lblDefaultAlbumName
+            // 
+            this.lblDefaultAlbumName.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblDefaultAlbumName.AutoSize = true;
+            this.lblDefaultAlbumName.Location = new System.Drawing.Point(4, 59);
+            this.lblDefaultAlbumName.Name = "lblDefaultAlbumName";
+            this.lblDefaultAlbumName.Size = new System.Drawing.Size(148, 28);
+            this.lblDefaultAlbumName.TabIndex = 5;
+            this.lblDefaultAlbumName.Text = "Default Album Name";
+            this.lblDefaultAlbumName.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // txtDefaultAlbumName
+            // 
+            this.txtDefaultAlbumName.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtDefaultAlbumName.Location = new System.Drawing.Point(159, 62);
+            this.txtDefaultAlbumName.Name = "txtDefaultAlbumName";
+            this.txtDefaultAlbumName.Size = new System.Drawing.Size(658, 22);
+            this.txtDefaultAlbumName.TabIndex = 6;
+            // 
+            // btnSave
+            // 
+            this.btnSave.AutoSize = true;
+            this.btnSave.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnSave.Location = new System.Drawing.Point(0, 375);
+            this.btnSave.Name = "btnSave";
+            this.btnSave.Size = new System.Drawing.Size(396, 75);
+            this.btnSave.TabIndex = 0;
+            this.btnSave.Text = "Save and Exit";
+            this.btnSave.UseVisualStyleBackColor = true;
+            this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
+            // 
+            // btnExit
+            // 
+            this.btnExit.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnExit.AutoSize = true;
+            this.btnExit.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.btnExit.Location = new System.Drawing.Point(402, 375);
+            this.btnExit.Name = "btnExit";
+            this.btnExit.Size = new System.Drawing.Size(396, 75);
+            this.btnExit.TabIndex = 4;
+            this.btnExit.Text = "Exit Without Saving";
+            this.btnExit.UseVisualStyleBackColor = true;
+            this.btnExit.Click += new System.EventHandler(this.btnExit_Click);
+            // 
+            // lblArtistOutputFile
+            // 
+            this.lblArtistOutputFile.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblArtistOutputFile.AutoSize = true;
+            this.lblArtistOutputFile.Location = new System.Drawing.Point(4, 88);
+            this.lblArtistOutputFile.Name = "lblArtistOutputFile";
+            this.lblArtistOutputFile.Size = new System.Drawing.Size(148, 28);
+            this.lblArtistOutputFile.TabIndex = 7;
+            this.lblArtistOutputFile.Text = "Artist Output File";
+            this.lblArtistOutputFile.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // txtArtistOutputFile
+            // 
+            this.txtArtistOutputFile.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtArtistOutputFile.Location = new System.Drawing.Point(159, 91);
+            this.txtArtistOutputFile.Name = "txtArtistOutputFile";
+            this.txtArtistOutputFile.Size = new System.Drawing.Size(658, 22);
+            this.txtArtistOutputFile.TabIndex = 8;
+            // 
+            // lblTrackTitleOutputFile
+            // 
+            this.lblTrackTitleOutputFile.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblTrackTitleOutputFile.AutoSize = true;
+            this.lblTrackTitleOutputFile.Location = new System.Drawing.Point(4, 117);
+            this.lblTrackTitleOutputFile.Name = "lblTrackTitleOutputFile";
+            this.lblTrackTitleOutputFile.Size = new System.Drawing.Size(148, 28);
+            this.lblTrackTitleOutputFile.TabIndex = 9;
+            this.lblTrackTitleOutputFile.Text = "Track Title Output File";
+            this.lblTrackTitleOutputFile.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // txtTrackTitleOutputFile
+            // 
+            this.txtTrackTitleOutputFile.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtTrackTitleOutputFile.Location = new System.Drawing.Point(159, 120);
+            this.txtTrackTitleOutputFile.Name = "txtTrackTitleOutputFile";
+            this.txtTrackTitleOutputFile.Size = new System.Drawing.Size(658, 22);
+            this.txtTrackTitleOutputFile.TabIndex = 10;
+            // 
+            // lblAlbumOutputFile
+            // 
+            this.lblAlbumOutputFile.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblAlbumOutputFile.AutoSize = true;
+            this.lblAlbumOutputFile.Location = new System.Drawing.Point(4, 146);
+            this.lblAlbumOutputFile.Name = "lblAlbumOutputFile";
+            this.lblAlbumOutputFile.Size = new System.Drawing.Size(148, 28);
+            this.lblAlbumOutputFile.TabIndex = 11;
+            this.lblAlbumOutputFile.Text = "Album Output File";
+            this.lblAlbumOutputFile.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // txtAlbumOutputFile
+            // 
+            this.txtAlbumOutputFile.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtAlbumOutputFile.Location = new System.Drawing.Point(159, 149);
+            this.txtAlbumOutputFile.Name = "txtAlbumOutputFile";
+            this.txtAlbumOutputFile.Size = new System.Drawing.Size(658, 22);
+            this.txtAlbumOutputFile.TabIndex = 12;
+            // 
+            // lblArtworkOutputFile
+            // 
+            this.lblArtworkOutputFile.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblArtworkOutputFile.AutoSize = true;
+            this.lblArtworkOutputFile.Location = new System.Drawing.Point(4, 175);
+            this.lblArtworkOutputFile.Name = "lblArtworkOutputFile";
+            this.lblArtworkOutputFile.Size = new System.Drawing.Size(148, 28);
+            this.lblArtworkOutputFile.TabIndex = 13;
+            this.lblArtworkOutputFile.Text = "Artwork Output File";
+            this.lblArtworkOutputFile.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // txtArtworkOutputFile
+            // 
+            this.txtArtworkOutputFile.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.txtArtworkOutputFile.Location = new System.Drawing.Point(159, 178);
+            this.txtArtworkOutputFile.Name = "txtArtworkOutputFile";
+            this.txtArtworkOutputFile.Size = new System.Drawing.Size(658, 22);
+            this.txtArtworkOutputFile.TabIndex = 14;
+            // 
+            // SettingsForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(800, 450);
+            this.Controls.Add(this.btnExit);
+            this.Controls.Add(this.tableLayoutPanel1);
+            this.Controls.Add(this.btnSave);
+            this.Name = "SettingsForm";
+            this.Text = "SettingsForm";
+            this.Load += new System.EventHandler(this.SettingsForm_Load);
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+        private System.Windows.Forms.Label lblDefaultArtistName;
+        private System.Windows.Forms.TextBox txtDefaultArtist;
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.TextBox txtDefaultTrackTitle;
+        private System.Windows.Forms.Label lblDefaultTrackTitle;
+        private System.Windows.Forms.TextBox txtDefaultAlbumName;
+        private System.Windows.Forms.Label lblDefaultAlbumName;
+        private System.Windows.Forms.Button btnSave;
+        private System.Windows.Forms.Button btnExit;
+        private System.Windows.Forms.Label lblArtistOutputFile;
+        private System.Windows.Forms.TextBox txtArtistOutputFile;
+        private System.Windows.Forms.Label lblTrackTitleOutputFile;
+        private System.Windows.Forms.TextBox txtTrackTitleOutputFile;
+        private System.Windows.Forms.TextBox txtAlbumOutputFile;
+        private System.Windows.Forms.Label lblArtworkOutputFile;
+        private System.Windows.Forms.Label lblAlbumOutputFile;
+        private System.Windows.Forms.TextBox txtArtworkOutputFile;
+    }
+}

--- a/ExporterConfiguration/SettingsForm.cs
+++ b/ExporterConfiguration/SettingsForm.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Windows.Forms;
+
+namespace MusicBeePlugin
+{
+    public partial class SettingsForm : Form
+    {
+        public SettingsForm()
+        {
+            InitializeComponent();
+        }
+
+        private void SettingsForm_Load(object sender, System.EventArgs e)
+        {
+            txtDefaultArtist.Text = CustomSettings.TrackDetails.Instance.DefaultArtistName;
+            txtDefaultTrackTitle.Text = CustomSettings.TrackDetails.Instance.DefaultTrackTitle;
+            txtDefaultAlbumName.Text = CustomSettings.TrackDetails.Instance.DefaultAlbumName;
+            
+            txtArtistOutputFile.Text = CustomSettings.TrackDetails.Instance.ArtworkOutputPath;
+            txtTrackTitleOutputFile.Text = CustomSettings.TrackDetails.Instance.TrackTitleOutputPath;
+            txtAlbumOutputFile.Text = CustomSettings.TrackDetails.Instance.AlbumNameOutputPath;
+            txtArtworkOutputFile.Text = CustomSettings.TrackDetails.Instance.ArtworkOutputPath;
+
+        }
+
+        private void btnSave_Click(object sender, EventArgs e)
+        {
+            CustomSettings.TrackDetails.Instance.DefaultArtistName = txtDefaultArtist.Text;
+            CustomSettings.TrackDetails.Instance.DefaultTrackTitle = txtDefaultTrackTitle.Text;
+            CustomSettings.TrackDetails.Instance.DefaultAlbumName = txtDefaultAlbumName.Text;
+
+            CustomSettings.TrackDetails.Instance.ArtistNameOutputPath = txtArtistOutputFile.Text;
+            CustomSettings.TrackDetails.Instance.TrackTitleOutputPath = txtTrackTitleOutputFile.Text;
+            CustomSettings.TrackDetails.Instance.AlbumNameOutputPath = txtAlbumOutputFile.Text;
+            CustomSettings.TrackDetails.Instance.ArtworkOutputPath = txtArtworkOutputFile.Text;
+
+            CustomSettings.Persistence.SavePluginSettings();
+            Close();
+        }
+
+        private void btnExit_Click(object sender, EventArgs e)
+        {
+            Close();
+        }
+    }
+}

--- a/ExporterConfiguration/SettingsForm.resx
+++ b/ExporterConfiguration/SettingsForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/MusicBeeNowPlayingOBS.csproj
+++ b/MusicBeeNowPlayingOBS.csproj
@@ -71,6 +71,9 @@
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.12.0.3\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
@@ -78,12 +81,20 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ExporterConfiguration\CustomSettings.cs" />
     <Compile Include="MusicBeeInterface.cs" />
     <Compile Include="NowPlayingOBSExporter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ExporterConfiguration\SettingsForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="ExporterConfiguration\SettingsForm.Designer.cs">
+      <DependentUpon>SettingsForm.cs</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include=".NETFramework,Version=v4.0">
@@ -107,7 +118,20 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="ExporterConfiguration\SettingsForm.resx">
+      <DependentUpon>SettingsForm.cs</DependentUpon>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>
+    </PreBuildEvent>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PostBuildEvent>copy /Y "$(TargetDir)\*.*" "F:\workspace\External References\MusicBeePortable\Plugins"</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/MusicBeeNowPlayingOBS.sln
+++ b/MusicBeeNowPlayingOBS.sln
@@ -5,6 +5,24 @@ VisualStudioVersion = 16.0.30320.27
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MusicBeeNowPlayingOBS", "MusicBeeNowPlayingOBS.csproj", "{F5D46BA1-6F21-40EF-9695-46105CCACD08}"
 EndProject
+Project("{911E67C6-3D85-4FCE-B560-20A9C3E3FF48}") = "MusicBee", "..\External References\MusicBeePortable\MusicBee.exe", "{0D3D2D2F-350D-4CF3-989B-E04521CC1DFF}"
+	ProjectSection(DebuggerProjectSystem) = preProject
+		PortSupplier = 00000000-0000-0000-0000-000000000000
+		Executable = F:\workspace\External References\MusicBeePortable\MusicBee.exe
+		RemoteMachine = DESKTOP-3DKE6FE
+		StartingDirectory = F:\workspace\External References\MusicBeePortable
+		Environment = Default
+		LaunchingEngine = 00000000-0000-0000-0000-000000000000
+		UseLegacyDebugEngines = No
+		LaunchSQLEngine = No
+		AttachLaunchAction = No
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A2B0ECB2-8B4F-4F2B-AF5E-40A86D0758AD}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -13,14 +31,18 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{F5D46BA1-6F21-40EF-9695-46105CCACD08}.Debug|Any CPU.ActiveCfg = Release|x86
-		{F5D46BA1-6F21-40EF-9695-46105CCACD08}.Debug|Any CPU.Build.0 = Release|x86
+		{F5D46BA1-6F21-40EF-9695-46105CCACD08}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{F5D46BA1-6F21-40EF-9695-46105CCACD08}.Debug|Any CPU.Build.0 = Debug|x86
 		{F5D46BA1-6F21-40EF-9695-46105CCACD08}.Debug|x86.ActiveCfg = Debug|x86
 		{F5D46BA1-6F21-40EF-9695-46105CCACD08}.Debug|x86.Build.0 = Debug|x86
 		{F5D46BA1-6F21-40EF-9695-46105CCACD08}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F5D46BA1-6F21-40EF-9695-46105CCACD08}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F5D46BA1-6F21-40EF-9695-46105CCACD08}.Release|x86.ActiveCfg = Release|x86
 		{F5D46BA1-6F21-40EF-9695-46105CCACD08}.Release|x86.Build.0 = Release|x86
+		{0D3D2D2F-350D-4CF3-989B-E04521CC1DFF}.Debug|Any CPU.ActiveCfg = Release|x86
+		{0D3D2D2F-350D-4CF3-989B-E04521CC1DFF}.Debug|x86.ActiveCfg = Release|x86
+		{0D3D2D2F-350D-4CF3-989B-E04521CC1DFF}.Release|Any CPU.ActiveCfg = Release|x86
+		{0D3D2D2F-350D-4CF3-989B-E04521CC1DFF}.Release|x86.ActiveCfg = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ TBD
 What's all the bells and whistles this project can perform?
 * Export track information such as Music Artist, Track Title, Album Name and Cover Artwork with configurable default values.
 
+## Outstanding Features
+* Directory selection dialog to prompt user the location for generated output. (Currently, user has to provide path as string value)
+
 ## Contributing
 
 If you'd like to contribute, please fork the repository and use a feature

--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net40-client" />
+</packages>


### PR DESCRIPTION
All storage path defaults to Plugin Folder allocated by MusicBee API interface.
Loads persisted configurations into memory everytime the plugin is configured from GUI.
Removes Plugin Folder when user uninstalls plugins,
but does not clean up files that are generated outside the plugin folder.